### PR TITLE
Fix propagation for ops

### DIFF
--- a/.github/skills/debugging-shape-inference.md
+++ b/.github/skills/debugging-shape-inference.md
@@ -1,0 +1,107 @@
+# Debugging Shape Inference Errors
+
+## Diagnosing "Inferred shape and existing shape differ" from ONNX C++
+
+When `onnx.shape_inference.infer_shapes(model, strict_mode=True)` raises
+`ShapeInferenceError: Inferred shape and existing shape differ in dimension N`,
+the error does **not** include the node or value name. Use the following
+workflow to locate the offending value.
+
+### Step 1: Confirm the error source
+
+```python
+import onnx
+
+model = onnx.load("model.onnx")
+try:
+    onnx.shape_inference.infer_shapes(model, data_prop=True, strict_mode=True)
+except Exception as e:
+    print(e)  # Note the dimension index and values, e.g. dim 0: (4) vs (5)
+```
+
+### Step 2: Strip value_info and re-infer
+
+If the model infers cleanly without `value_info`, the bug is in one of those
+annotations (not in the graph structure):
+
+```python
+stripped = onnx.ModelProto()
+stripped.CopyFrom(model)
+del stripped.graph.value_info[:]
+onnx.shape_inference.infer_shapes(stripped, data_prop=True, strict_mode=True)
+# If this succeeds, the error is in value_info
+```
+
+### Step 3: Binary search for the problematic value_info entry
+
+```python
+vis = list(model.graph.value_info)
+
+def test_with_vis(model, vis_to_keep):
+    m = onnx.ModelProto()
+    m.CopyFrom(model)
+    del m.graph.value_info[:]
+    for vi in vis_to_keep:
+        m.graph.value_info.append(vi)
+    try:
+        onnx.shape_inference.infer_shapes(m, data_prop=True, strict_mode=True)
+        return True
+    except:
+        return False
+
+lo, hi = 0, len(vis)
+while lo < hi:
+    mid = (lo + hi) // 2
+    if test_with_vis(model, vis[:mid + 1]):
+        lo = mid + 1
+    else:
+        hi = mid
+
+bad_vi = vis[lo]
+print(f"Problematic value: {bad_vi.name}")
+```
+
+### Step 4: Compare against ground truth
+
+For initializers, the actual tensor shape is ground truth:
+
+```python
+for init in model.graph.initializer:
+    if init.name == bad_vi.name:
+        print(f"Initializer shape: {list(init.dims)}")
+
+# Extract the annotated shape from value_info
+dims = []
+for d in bad_vi.type.tensor_type.shape.dim:
+    dims.append(d.dim_value if d.HasField("dim_value") else d.dim_param)
+print(f"Annotated shape: {dims}")
+```
+
+For intermediate values, compare against what ONNX C++ infers from scratch:
+
+```python
+stripped = onnx.ModelProto()
+stripped.CopyFrom(model)
+del stripped.graph.value_info[:]
+inferred = onnx.shape_inference.infer_shapes(stripped, data_prop=True)
+
+for vi in inferred.graph.value_info:
+    if vi.name == bad_vi.name:
+        # This is what ONNX C++ thinks the shape should be
+        print(vi)
+```
+
+## Common root causes
+
+| Symptom | Likely cause |
+|---------|-------------|
+| Initializer shape != value_info shape | Bad annotation in the original model. Fix: correct shapes from the actual tensor at inference start. |
+| Intermediate value has wrong concrete dim | Our op inference computed a wrong dimension. Fix: debug the specific op's `infer_*` function. |
+| Symbolic dim where C++ infers concrete | Our inference was less precise but not wrong. Usually not an error in strict mode. |
+
+## Prevention: initializer shape correction
+
+The engine (`_engine.py`) corrects initializer shapes at the start of
+`_process_graph` using the actual tensor as ground truth. This handles
+malformed models where `value_info` annotations disagree with initializer
+tensor shapes.

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+*.onnx

--- a/src/onnx_shape_inference/_ops/_reshape_test.py
+++ b/src/onnx_shape_inference/_ops/_reshape_test.py
@@ -92,7 +92,7 @@ class ReshapeTest(unittest.TestCase):
         self.assertEqual(actual, [ts(FLOAT, [0, 4])])
 
     def test_neg_one_non_static_input(self):
-        """When input shape is symbolic, -1 becomes a new symbolic dim."""
+        """When input shape has one symbolic dim, -1 resolves to that dim."""
         data = ir.Value(
             name="data",
             shape=ir.Shape([ir.SymbolicDim("batch"), 12]),
@@ -105,7 +105,7 @@ class ReshapeTest(unittest.TestCase):
             [data, shape_val],
             opset_version=17,
         )
-        self.assertEqual(actual, [ts(FLOAT, ["_d0", 3, 4])])
+        self.assertEqual(actual, [ts(FLOAT, ["batch", 3, 4])])
 
     def test_dynamic_shape_with_known_rank(self):
         """Dynamic shape input (non-const) but shape input's shape gives output rank."""
@@ -128,7 +128,7 @@ class ReshapeTest(unittest.TestCase):
         self.assertEqual(actual, [ts(FLOAT, ["_d0", "_d1"])])
 
     def test_neg_one_with_symbolic_known_dims(self):
-        """Reshape with -1 where known dims don't fully resolve (symbolic in output)."""
+        """Reshape with -1 where one input dim is symbolic resolves to that dim."""
         data = ir.Value(
             name="data",
             shape=ir.Shape([ir.SymbolicDim("N"), 3, 4]),
@@ -141,7 +141,7 @@ class ReshapeTest(unittest.TestCase):
             [data, shape_val],
             opset_version=17,
         )
-        self.assertEqual(actual, [ts(FLOAT, ["_d0", 12])])
+        self.assertEqual(actual, [ts(FLOAT, ["N", 12])])
 
     def test_zero_dim_no_input_shape(self):
         """0-dim in target with no input shape → symbolic dim."""


### PR DESCRIPTION
This pull request introduces significant improvements to shape inference, especially for symbolic dimensions, and enhances debugging support for ONNX shape inference errors. The most important changes are grouped below:

### Improved symbolic shape inference and propagation

* Enhanced the `Reshape` op to propagate symbolic values and infer the `-1` dimension symbolically when the input shape contains exactly one symbolic dimension, improving accuracy for models with symbolic batch sizes or similar patterns. [[1]](diffhunk://#diff-ae073adbd1dc770668516263029037c6b77ce9dc3485427bb7576a54efc7f4b9L77-R78) [[2]](diffhunk://#diff-ae073adbd1dc770668516263029037c6b77ce9dc3485427bb7576a54efc7f4b9R95-R145)
* Updated the `Split` op to propagate symbolic values to outputs when splitting a 1-D tensor along axis 0, enabling more precise tracking of symbolic shapes across split operations.
* Extended variadic elementwise ops (`Max`, `Min`, `Sum`) to propagate symbolic values when all inputs have symbolic values, improving symbolic reasoning for these operations. [[1]](diffhunk://#diff-67ce5140ded536c1ec04521ae2119272a3aa794400b3638c6e6f3c775d1d64cfR115-R121) [[2]](diffhunk://#diff-67ce5140ded536c1ec04521ae2119272a3aa794400b3638c6e6f3c775d1d64cfR145-R156)

### Debugging and prevention of shape annotation errors

* Added a comprehensive debugging guide (`.github/skills/debugging-shape-inference.md`) describing workflows to diagnose "Inferred shape and existing shape differ" errors, including binary search for problematic `value_info` annotations and prevention strategies.
* Modified the shape inference engine (`_engine.py`) to automatically correct initializer shapes at the start of graph processing, treating the actual tensor shape as ground truth over any potentially incorrect `value_info` annotation.

### Expanded and updated test coverage

* Added new tests for propagation of symbolic values through `Reshape`, `Split`, and elementwise ops, and updated existing tests to reflect the improved symbolic inference logic. [[1]](diffhunk://#diff-2edd9356d48c14bae17f803d617506b53b827884d514569b1743043cacbfcaf9R427-R509) [[2]](diffhunk://#diff-e4cd8e6b92bc52427e382b718ea4079b16aac145005eff767811f054c6d0fdf1L95-R95) [[3]](diffhunk://#diff-e4cd8e6b92bc52427e382b718ea4079b16aac145005eff767811f054c6d0fdf1L108-R108) [[4]](diffhunk://#diff-e4cd8e6b92bc52427e382b718ea4079b16aac145005eff767811f054c6d0fdf1L131-R131) [[5]](diffhunk://#diff-e4cd8e6b92bc52427e382b718ea4079b16aac145005eff767811f054c6d0fdf1L144-R144)