### PR TITLE
Store const_value in values; improve Slice computation

### DIFF
--- a/src/onnx_shape_inference/_context.py
+++ b/src/onnx_shape_inference/_context.py
@@ -497,8 +497,24 @@ class ShapeInferenceContext:
         self._symbolic_values[value] = data
 
         # When fully concrete, also store as a constant tensor
-        if all(isinstance(d, int) for d in data) and value.const_value is None:
-            value.const_value = ir.tensor(data, dtype=ir.DataType.INT64, name=value.name)
+        if value.shape is None:
+            logger.debug("Cannot set const_value for %s since shape is unknown", value.name)
+            return
+        if (
+            len(value.shape) <= 1
+            and all(isinstance(d, int) for d in data)
+            and value.const_value is None
+        ):
+            if value.dtype is not None:
+                dtype = value.dtype
+            else:
+                dtype = ir.DataType.INT64
+            if len(value.shape) == 0 and data:
+                data = data[0]
+                logger.debug("Setting const_value for scalar %s to %s", value.name, data)
+            else:
+                logger.debug("Setting const_value for %s to %s", value.name, data)
+            value.const_value = ir.tensor(data, dtype=dtype, name=value.name)
 
     def get_symbolic_value(
         self,

--- a/src/onnx_shape_inference/_context.py
+++ b/src/onnx_shape_inference/_context.py
@@ -486,11 +486,19 @@ class ShapeInferenceContext:
         (e.g., shape tensors) so that downstream ops like Reshape can read
         them even when the tensor is not a constant.
 
+        When all elements are concrete integers, the value's ``const_value``
+        is also set so that the tensor is available to downstream consumers
+        that read constants directly.
+
         Args:
             value: The value to annotate.
             data: A list of known element values (int or SymbolicDim).
         """
         self._symbolic_values[value] = data
+
+        # When fully concrete, also store as a constant tensor
+        if all(isinstance(d, int) for d in data) and value.const_value is None:
+            value.const_value = ir.tensor(data, dtype=ir.DataType.INT64, name=value.name)
 
     def get_symbolic_value(
         self,

--- a/src/onnx_shape_inference/_ops/_slice.py
+++ b/src/onnx_shape_inference/_ops/_slice.py
@@ -43,7 +43,12 @@ def infer_slice(ctx: _context.ShapeInferenceContext, node: ir.Node) -> None:
     starts = _read_const_ints(node.inputs[1])
     ends = _read_const_ints(node.inputs[2])
 
-    if starts is None or ends is None:
+    # Try symbolic value for ends when not constant
+    ends_sym: list[int | ir.SymbolicDim] | None = None
+    if ends is None:
+        ends_sym = ctx.get_symbolic_value(node.inputs[2])
+
+    if starts is None or (ends is None and ends_sym is None):
         # Dynamic starts/ends — same rank, sliced dims are symbolic
         if len(node.outputs) > 0:
             symbolic_dims: list[int | ir.SymbolicDim] = [
@@ -65,8 +70,17 @@ def infer_slice(ctx: _context.ShapeInferenceContext, node: ir.Node) -> None:
     if steps is None:
         steps = [1] * len(starts)
 
+    # Use concrete ends or symbolic ends
+    ends_values: list[int] | list[int | ir.SymbolicDim]
+    if ends is not None:
+        ends_values = ends
+    else:
+        assert ends_sym is not None
+        ends_values = ends_sym
+
     output_dims: list[int | ir.SymbolicDim] = list(input_shape.dims)
-    for start, end, axis, step in zip(starts, ends, axes, steps):
+    for i, (start, axis, step) in enumerate(zip(starts, axes, steps)):
+        end = ends_values[i]
         if axis < 0:
             axis += rank
         if not 0 <= axis < rank:
@@ -77,7 +91,14 @@ def infer_slice(ctx: _context.ShapeInferenceContext, node: ir.Node) -> None:
             ctx.record_error(node, f"Step cannot be 0 for axis {axis}")
             return
 
-        if isinstance(dim, int):
+        if not isinstance(end, int):
+            # Symbolic end: if start=0 and step=1 and end matches input dim,
+            # the slice is a no-op for this axis
+            if start == 0 and step == 1 and end == dim:
+                output_dims[axis] = dim
+            else:
+                output_dims[axis] = ctx.new_symbolic_dim()
+        elif isinstance(dim, int):
             # Clamp start/end to [0, dim] for positive step, [-1, dim-1] for negative
             if step > 0:
                 clamped_start = max(0, min(start if start >= 0 else start + dim, dim))
@@ -91,12 +112,29 @@ def infer_slice(ctx: _context.ShapeInferenceContext, node: ir.Node) -> None:
             )
             output_dims[axis] = slice_len
         else:
-            # Symbolic dim: if start/end are non-negative and not sentinel
-            # values, we can compute the slice length directly since it
-            # doesn't depend on the actual dimension size, assuming input has at least that many elements.
-            # This is a practical assumption.
+            # Symbolic dim with concrete start/end/step.
+            #
+            # Sentinel values (INT64_MAX, INT64_MIN, INT32_MAX, INT32_MIN) are
+            # used by ONNX Slice to mean "up to the end" or "from the beginning"
+            # depending on the sign of *step*.  When such sentinels appear with
+            # a zero start (forward) or as both start and end (reverse), the
+            # slice covers the entire axis and the output dim equals the input
+            # dim — even when that dim is symbolic.
+            #
+            # For non-sentinel, non-negative start/end we can compute the slice
+            # length directly as ``ceil((end - start) / step)`` because the
+            # result does not depend on the actual (unknown) dimension size.
+            # This assumes the tensor has at least ``end`` elements along the
+            # axis, which is a practical assumption for well-formed models.
             sentinels = {2**63 - 1, -(2**63), 2**31 - 1, -(2**31)}
-            if start >= 0 and end >= 0 and start not in sentinels and end not in sentinels:
+
+            # Full forward slice: start=0, step=1, end=sentinel → same dim
+            if start == 0 and step == 1 and end in sentinels:
+                output_dims[axis] = dim
+            # Full reverse slice: start=sentinel, step=-1, end=negative sentinel
+            elif step == -1 and start in sentinels and end in sentinels:
+                output_dims[axis] = dim
+            elif start >= 0 and end >= 0 and start not in sentinels and end not in sentinels:
                 slice_len = max(0, -(-max(0, end - start) // abs(step)))
                 output_dims[axis] = slice_len
             else:
@@ -108,7 +146,7 @@ def infer_slice(ctx: _context.ShapeInferenceContext, node: ir.Node) -> None:
 
         # Propagate symbolic_value for 1-D tensors sliced on axis 0
         sym_val = ctx.get_symbolic_value(data)
-        if sym_val is not None and rank == 1 and len(axes) == 1 and axes[0] == 0:
+        if sym_val is not None and ends is not None and rank == 1 and len(axes) == 1 and axes[0] == 0:
             n = len(sym_val)
             s, e, st = starts[0], ends[0], steps[0]
             # Clamp start/end like Python slicing

--- a/src/onnx_shape_inference/_ops/_slice.py
+++ b/src/onnx_shape_inference/_ops/_slice.py
@@ -146,7 +146,13 @@ def infer_slice(ctx: _context.ShapeInferenceContext, node: ir.Node) -> None:
 
         # Propagate symbolic_value for 1-D tensors sliced on axis 0
         sym_val = ctx.get_symbolic_value(data)
-        if sym_val is not None and ends is not None and rank == 1 and len(axes) == 1 and axes[0] == 0:
+        if (
+            sym_val is not None
+            and ends is not None
+            and rank == 1
+            and len(axes) == 1
+            and axes[0] == 0
+        ):
             n = len(sym_val)
             s, e, st = starts[0], ends[0], steps[0]
             # Clamp start/end like Python slicing

--- a/src/onnx_shape_inference/_ops/_slice_test.py
+++ b/src/onnx_shape_inference/_ops/_slice_test.py
@@ -95,6 +95,21 @@ class SliceTest(unittest.TestCase):
         actual = self._run(ts(FLOAT, ["N", 10]), [2], [8], [1], [1])
         self.assertEqual(actual, [ts(FLOAT, ["N", 6])])
 
+    def test_symbolic_dim_sentinel_end_forward_preserves_dim(self):
+        """start=0, step=1, end=INT_MAX on symbolic dim → preserves dim."""
+        actual = self._run(ts(FLOAT, ["N", 10]), [0], [2**63 - 1], [0], [1])
+        self.assertEqual(actual, [ts(FLOAT, ["N", 10])])
+
+    def test_symbolic_dim_sentinel_end_int32_max(self):
+        """start=0, step=1, end=INT32_MAX on symbolic dim → preserves dim."""
+        actual = self._run(ts(FLOAT, ["N", 10]), [0], [2**31 - 1], [0], [1])
+        self.assertEqual(actual, [ts(FLOAT, ["N", 10])])
+
+    def test_symbolic_dim_sentinel_reverse_preserves_dim(self):
+        """Full reverse: start=INT_MAX, end=INT_MIN, step=-1 → preserves dim."""
+        actual = self._run(ts(FLOAT, ["N", 10]), [2**63 - 1], [-(2**63)], [0], [-1])
+        self.assertEqual(actual, [ts(FLOAT, ["N", 10])])
+
     def test_missing_input_shape(self):
         data = ir.Value(name="data", type=ir.TensorType(FLOAT))
         starts = const_value([0], "starts")
@@ -151,6 +166,119 @@ class SliceTest(unittest.TestCase):
             opset_version=17,
         )
         self.assertEqual(actual, [ts(FLOAT, ["_d0", "_d1"])])
+
+    def _run_with_symbolic_ends(
+        self, input_ts, starts, ends_sym, axes=None, steps=None
+    ):
+        """Run Slice inference with a symbolic (non-constant) ends input."""
+        from onnx_shape_inference import _context, _registry
+
+        data = ir.Value(name="data", shape=input_ts.shape, type=input_ts.type)
+        ends_val = ir.Value(
+            name="ends", type=ir.TensorType(ir.DataType.INT64), shape=ir.Shape([len(ends_sym)])
+        )
+        inputs = [
+            data,
+            const_value(starts, "starts"),
+            ends_val,
+        ]
+        if axes is not None:
+            inputs.append(const_value(axes, "axes"))
+        if steps is not None:
+            if axes is None:
+                inputs.append(ir.Value(name="axes_empty"))
+            inputs.append(const_value(steps, "steps"))
+
+        output_values = [ir.Value(name="output_0")]
+        node = ir.Node("", "Slice", inputs=inputs, outputs=output_values, attributes={})
+        ctx = _context.ShapeInferenceContext({"": 17})
+        ctx.name_anonymous_dims(data)
+        # Set symbolic value for ends
+        ctx.set_symbolic_value(ends_val, ends_sym)
+
+        func = _registry.registry.get("", "Slice", version=17)
+        func(ctx, node)
+        return [ir.TypeAndShape(v.type, v.shape) for v in output_values]
+
+    def test_symbolic_ends_match_input_shape(self):
+        """Slice with symbolic ends matching input dims is a no-op per axis."""
+        batch = ir.SymbolicDim("batch")
+        actual = self._run_with_symbolic_ends(
+            ts(FLOAT, ["batch", 100]),
+            starts=[0, 0],
+            ends_sym=[batch, 100],
+            axes=[0, 1],
+            steps=[1, 1],
+        )
+        self.assertEqual(actual, [ts(FLOAT, ["batch", 100])])
+
+    def test_symbolic_ends_no_match_gives_new_dim(self):
+        """Slice with symbolic end that doesn't match input dim gives a new symbolic dim."""
+        other = ir.SymbolicDim("other")
+        actual = self._run_with_symbolic_ends(
+            ts(FLOAT, ["batch", 100]),
+            starts=[0, 0],
+            ends_sym=[other, 100],
+            axes=[0, 1],
+            steps=[1, 1],
+        )
+        # axis 0: end=other != batch → new symbolic dim; axis 1: end=100 concrete → 100
+        self.assertIsNotNone(actual[0].shape)
+        self.assertNotEqual(actual[0].shape[0], ir.SymbolicDim("batch"))
+        self.assertEqual(actual[0].shape[1], 100)
+
+    def test_symbolic_ends_start_nonzero_gives_new_dim(self):
+        """Slice with symbolic end and start!=0 gives a new symbolic dim."""
+        batch = ir.SymbolicDim("batch")
+        actual = self._run_with_symbolic_ends(
+            ts(FLOAT, ["batch", 100]),
+            starts=[1, 0],
+            ends_sym=[batch, 100],
+            axes=[0, 1],
+            steps=[1, 1],
+        )
+        self.assertIsNotNone(actual[0].shape)
+        # axis 0: start=1, so even though end=batch=input_dim, it's not identity
+        self.assertIsInstance(actual[0].shape[0], ir.SymbolicDim)
+        self.assertEqual(actual[0].shape[1], 100)
+
+    def test_symbolic_ends_step_not_one_gives_new_dim(self):
+        """Slice with symbolic end and step!=1 gives a new symbolic dim."""
+        batch = ir.SymbolicDim("batch")
+        actual = self._run_with_symbolic_ends(
+            ts(FLOAT, ["batch", 100]),
+            starts=[0, 0],
+            ends_sym=[batch, 100],
+            axes=[0, 1],
+            steps=[2, 1],
+        )
+        self.assertIsNotNone(actual[0].shape)
+        # axis 0: step=2, so even though start=0 and end=batch, result is not batch
+        self.assertIsInstance(actual[0].shape[0], ir.SymbolicDim)
+        self.assertEqual(actual[0].shape[1], 100)
+
+    def test_symbolic_ends_partial_axes(self):
+        """Slice with symbolic ends on a subset of axes preserves non-sliced dims."""
+        batch = ir.SymbolicDim("batch")
+        actual = self._run_with_symbolic_ends(
+            ts(FLOAT, ["batch", 100, 200]),
+            starts=[0],
+            ends_sym=[batch],
+            axes=[0],
+            steps=[1],
+        )
+        self.assertEqual(actual, [ts(FLOAT, ["batch", 100, 200])])
+
+    def test_symbolic_ends_concrete_dim_computed(self):
+        """Slice with symbolic ends on a concrete dim computes the result."""
+        actual = self._run_with_symbolic_ends(
+            ts(FLOAT, [10, 20]),
+            starts=[0, 0],
+            ends_sym=[10, 20],
+            axes=[0, 1],
+            steps=[1, 1],
+        )
+        self.assertEqual(actual, [ts(FLOAT, [10, 20])])
 
 
 if __name__ == "__main__":

--- a/src/onnx_shape_inference/_ops/_slice_test.py
+++ b/src/onnx_shape_inference/_ops/_slice_test.py
@@ -167,9 +167,7 @@ class SliceTest(unittest.TestCase):
         )
         self.assertEqual(actual, [ts(FLOAT, ["_d0", "_d1"])])
 
-    def _run_with_symbolic_ends(
-        self, input_ts, starts, ends_sym, axes=None, steps=None
-    ):
+    def _run_with_symbolic_ends(self, input_ts, starts, ends_sym, axes=None, steps=None):
         """Run Slice inference with a symbolic (non-constant) ends input."""
         from onnx_shape_inference import _context, _registry
 

--- a/src/onnx_shape_inference/_symbolic_shapes_test.py
+++ b/src/onnx_shape_inference/_symbolic_shapes_test.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import math
 import unittest
 
 import onnx_ir as ir
@@ -120,22 +121,16 @@ class SymbolicDimTest(unittest.TestCase):
         self.assertEqual(result.value, "6/N")
 
     def test_ceil(self):
-        import math
-
         dim = ir.SymbolicDim("N")
         result = math.ceil(dim / 3)
         self.assertEqual(result.value, "ceiling(N/3)")
 
     def test_floor(self):
-        import math
-
         dim = ir.SymbolicDim("N")
         result = math.floor(dim / 3)
         self.assertEqual(result.value, "floor(N/3)")
 
     def test_trunc(self):
-        import math
-
         dim = ir.SymbolicDim("N")
         result = math.trunc(dim)
         self.assertEqual(result.value, "N")


### PR DESCRIPTION
This pull request improves symbolic shape inference for the ONNX Slice operator by enabling support for symbolic (non-constant) ends, correctly handling sentinel values, and expanding test coverage for these cases. The changes allow the inference logic to better propagate symbolic dimensions through slicing operations, making the system more robust and accurate for dynamic shapes.

**Slice operator improvements:**

* Enhanced the Slice inference logic to accept symbolic (non-constant) ends, using symbolic values when constants are not available, and to propagate symbolic dimensions accordingly. [[1]](diffhunk://#diff-3f5b33500d237b5d88a3d3dc514c22a6dadde5b906d764bff8a44e4a69bd8259L46-R51) [[2]](diffhunk://#diff-3f5b33500d237b5d88a3d3dc514c22a6dadde5b906d764bff8a44e4a69bd8259R73-R83)
* Improved handling of sentinel values (e.g., INT64_MAX, INT32_MAX) in symbolic slicing, ensuring that full-range slices (including reverse) preserve the symbolic dimension, and added logic to assign new symbolic dimensions when the slice is not an identity. [[1]](diffhunk://#diff-3f5b33500d237b5d88a3d3dc514c22a6dadde5b906d764bff8a44e4a69bd8259L80-R101) [[2]](diffhunk://#diff-3f5b33500d237b5d88a3d3dc514c22a6dadde5b906d764bff8a44e4a69bd8259L94-R137)
* Fixed propagation of symbolic values for 1-D tensors to require concrete ends, preventing incorrect symbolic value propagation.

**Symbolic value management:**

* Updated the `set_symbolic_value` method to set `const_value` for a value when all elements are concrete, improving downstream constant propagation.

**Test coverage:**

* Added comprehensive tests for symbolic ends in Slice, including cases with sentinel values, symbolic ends matching or not matching input dims, partial axes, and step variations. [[1]](diffhunk://#diff-b6cebbf7195f5ad2435aeaa720a5194db54a0a4318724ce6e7d35dda67ef9c0aR98-R112) [[2]](diffhunk://#diff-b6cebbf7195f5ad2435aeaa720a5194db54a0a4318724ce6e7d35dda67ef9c0aR170-R282)

**Code maintenance:**

* Moved `import math` to the top of the test file and removed redundant imports from test methods for clarity and consistency. [[1]](diffhunk://#diff-3a0e38af35ac468e947bfc66c793908fec581a6c2a3b18df7224a3e5a9a395a4R7) [[2]](diffhunk://#diff-3a0e38af35ac468e947bfc66c793908fec581a6c2a3b18df7224a3e5a9a395a4L123-L138)