### PR TITLE
Save pkg.onnx_shape_inference.sym_data in values

### DIFF
--- a/src/onnx_shape_inference/__init__.py
+++ b/src/onnx_shape_inference/__init__.py
@@ -53,11 +53,14 @@ __all__ = [
     "broadcast_shapes",
     "check_inputs",
     "require_attr",
+    # Constants
+    "SYM_DATA_KEY",
 ]
 
 from onnx_shape_inference import _patch  # noqa: F401
 from onnx_shape_inference._broadcast import broadcast_shapes
 from onnx_shape_inference._context import (
+    SYM_DATA_KEY,
     OpUsageError,
     ShapeInferenceContext,
     ShapeInferenceError,

--- a/src/onnx_shape_inference/_context.py
+++ b/src/onnx_shape_inference/_context.py
@@ -9,6 +9,7 @@ __all__ = [
     "ShapeInferenceContext",
     "ShapeInferenceError",
     "ShapeMergePolicy",
+    "SYM_DATA_KEY",
 ]
 
 import logging
@@ -18,6 +19,8 @@ from typing import Literal
 import onnx_ir as ir
 
 logger = logging.getLogger(__name__)
+
+SYM_DATA_KEY = "pkg.onnx_shape_inference.sym_data"
 
 
 class ShapeInferenceError(ValueError):
@@ -495,7 +498,8 @@ class ShapeInferenceContext:
             data: A list of known element values (int or SymbolicDim).
         """
         self._symbolic_values[value] = data
-        value.metadata_props["pkg.onnx_shape_inference.sym_value"] = (
+        # Call it sym_data because it is always 1d list even for scalars
+        value.metadata_props[SYM_DATA_KEY] = (
             "[" + ",".join(str(x) if isinstance(x, int) else f'"{x}"' for x in data) + "]"
         )
 

--- a/src/onnx_shape_inference/_context.py
+++ b/src/onnx_shape_inference/_context.py
@@ -495,6 +495,9 @@ class ShapeInferenceContext:
             data: A list of known element values (int or SymbolicDim).
         """
         self._symbolic_values[value] = data
+        value.metadata_props["pkg.onnx_shape_inference.sym_value"] = (
+            "[" + ",".join(str(x) if isinstance(x, int) else f'"{x}"' for x in data) + "]"
+        )
 
         # When fully concrete, also store as a constant tensor
         if value.shape is None:


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `set_symbolic_value` method in `src/onnx_shape_inference/_context.py`. Now, whenever a symbolic value is set, its data is also stored as a formatted string in the `metadata_props` of the value, which can help with debugging or downstream processing.

- Symbolic value metadata:
  * The method now adds a `pkg.onnx_shape_inference.sym_data` property to `value.metadata_props`, storing a stringified list of the symbolic value's data for easier inspection and downstream tool use.